### PR TITLE
Patch for JingYang undo bug.

### DIFF
--- a/src/jingyang/JYEngine.cpp
+++ b/src/jingyang/JYEngine.cpp
@@ -94,6 +94,9 @@ void JYEngine::CmdUndo(benzene::HtpCommand &cmd) {
         m_player.m_cur_pattern_list=m_player.m_prev_pattern_list_stack.back();
         m_player.m_prev_pattern_list_stack.pop_back();
     }
+    //Board is rotated after first white move, so undoing first white move must undo the rotation.
+    if(m_game.History().size() < 3) 
+        m_player.m_is_rotate180=false;
     HexHtpEngine::CmdUndo(cmd);
 }
 


### PR DESCRIPTION
To reproduce the bug on master enter these commands:

1. `boardsize 9x9`
2. `genmove b`
3. `play w g5`
4. `genmove b`
5. `undo`
6. `undo`
7. `play w g3`
8. `genmove b`
9. `play w e3`
10. `genmove b`
11. `play w f2`
12. `genmove b1
13. `play w g2`
14. `genmove b`

At this point, the JingYang player attempts to play in g3 resulting in the error:
```
? illegal move:  black g3 (occupied)
```

The bug results from the player setting the `m_is_rotate180` flag but not properly undoing it. Testing the same line on the patched fork shows JingYang handling it correctly.