### PR TITLE
Fix build on macos

### DIFF
--- a/src/gtpengine/GtpEngine.cpp
+++ b/src/gtpengine/GtpEngine.cpp
@@ -19,7 +19,6 @@
 
 using boost::barrier;
 using boost::condition;
-using boost::thread;
 using boost::xtime;
 using boost::xtime_get;
 #endif
@@ -354,7 +353,7 @@ void ReadThread::Function::ExecuteSleepLine(const string& line)
             xtime_get(&time, boost::TIME_UTC);
         #endif
         time.sec += seconds;
-        thread::sleep(time);
+        boost::thread::sleep(time);
         cerr << "GtpEngine: sleep done\n";
     }
 }

--- a/src/smartgame/CMakeLists.txt
+++ b/src/smartgame/CMakeLists.txt
@@ -1,5 +1,10 @@
 file(GLOB smartgame_SRC *.cpp *.h *.hpp)
 
+if(${APPLE})
+  # otherwise ranlib will fail with the "has no symbols" error
+  list(FILTER smartgame_SRC EXCLUDE REGEX ".*SgProcess\..*")
+endif()
+
 add_library(fuego_smartgame STATIC ${smartgame_SRC})
 include_directories(${Boost_INCLUDE_DIRS})
 include_directories(

--- a/src/solver/SolverDB.hpp
+++ b/src/solver/SolverDB.hpp
@@ -132,7 +132,7 @@ SolverDBParameters& SolverDB<HASH, DB, DATA>::Parameters()
 template<class HASH, class DB, class DATA>
 void SolverDB<HASH, DB, DATA>::SetParameters(const SolverDBParameters& p)
 {
-    return m_param = p;
+    m_param = p;
 }
 
 template<class HASH, class DB, class DATA>


### PR DESCRIPTION
- The `SgProcess` object file is empty in case clang is used, however ranlib on macos does not allow those (it fails with the `... has no symbols` error)
- There was the following error because of `using boost::thread` and `using namespace std` simultaneously:
```
benzene-vanilla-cmake/src/gtpengine/GtpEngine.cpp:357:9: error: reference to 'thread' is ambiguous
        thread::sleep(time);
```
- I also fixed this:
```
benzene-vanilla-cmake/src/solver/SolverDB.hpp:135:5: error: void function 'SetParameters' should not return a value [-Wreturn-type]
    return m_param = p;
```