### PR TITLE
Fix a bug affecting parallelogram boards.

### DIFF
--- a/src/hex/HexEnvironment.cpp
+++ b/src/hex/HexEnvironment.cpp
@@ -18,7 +18,7 @@ HexEnvironment::HexEnvironment(int width, int height)
 void HexEnvironment::NewGame(int width, int height)
 {
     if (brd->GetPosition().Width() != width 
-        && brd->GetPosition().Height() != height)
+        || brd->GetPosition().Height() != height)
     {
         /** @todo Make board resizable? Until then, make sure all
             HexBoard parameters are copied here! */


### PR DESCRIPTION
When changing the board size from n x m to n x k, some of the internal board representations are not updated correctly, resulting in a bug. To reproduce:

boardsize 4 4
boardsize 4 2
play black a1
play black a2
play white b2
play white c2
showboard
dfpn-solve-state black

The answer is "white" although the position is clearly winning for Black. This pull request fixes the bug.